### PR TITLE
Allow use of an alternate LLVM/Clang, fix build with newer Clang, install executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,27 +18,40 @@ enable_testing()
 # Visual C++ Express Editions do not support solution folders.
 set_property(GLOBAL PROPERTY USE_FOLDERS OFF)
 
-# Patch LLVM CMake script to set USE_FOLDERS property to OFF.
-configure_file(
-    patch/llvm/CMakeLists.txt
-    ${CMAKE_SOURCE_DIR}/llvm/CMakeLists.txt
-    COPYONLY)
-add_subdirectory(llvm)
+option(USE_INSTALLED_CLANG "Use an installed clang/llvm?" OFF)
+if(USE_INSTALLED_CLANG)
+    find_package(LLVM REQUIRED)
+    include(AddLLVM)
+    macro(add_clang_executable name)
+      add_llvm_executable( ${name} ${ARGN} )
+      set_target_properties(${name} PROPERTIES FOLDER "Clang executables")
+    endmacro(add_clang_executable)
+    set(CLANG_INCLUDE_DIRS)
+    link_directories(${LLVM_LIBRARY_DIRS})
+else()
+    # Patch LLVM CMake script to set USE_FOLDERS property to OFF.
+    configure_file(
+        patch/llvm/CMakeLists.txt
+        ${CMAKE_SOURCE_DIR}/llvm/CMakeLists.txt
+        COPYONLY)
+    add_subdirectory(llvm)
 
-set(CLANG_BUILD_STANDALONE 1
-    CACHE INTERNAL "Build clang as standalone.")
-set(CLANG_PATH_TO_LLVM_SOURCE "${CMAKE_SOURCE_DIR}/llvm"
-    CACHE INTERNAL "Path to LLVM source directory.")
-set(CLANG_PATH_TO_LLVM_BUILD "${CMAKE_BINARY_DIR}/llvm"
-    CACHE INTERNAL "Path to LLVM build directory.")
+    set(CLANG_BUILD_STANDALONE 1
+        CACHE INTERNAL "Build clang as standalone.")
+    set(CLANG_PATH_TO_LLVM_SOURCE "${CMAKE_SOURCE_DIR}/llvm"
+        CACHE INTERNAL "Path to LLVM source directory.")
+    set(CLANG_PATH_TO_LLVM_BUILD "${CMAKE_BINARY_DIR}/llvm"
+        CACHE INTERNAL "Path to LLVM build directory.")
 
-# Patch clang CMake script to build it standalone.
-configure_file(
-    patch/clang/CMakeLists.txt
-    ${CMAKE_SOURCE_DIR}/clang/CMakeLists.txt
-    COPYONLY)
-add_subdirectory(clang)
-
+    # Patch clang CMake script to build it standalone.
+    configure_file(
+        patch/clang/CMakeLists.txt
+        ${CMAKE_SOURCE_DIR}/clang/CMakeLists.txt
+        COPYONLY)
+    add_subdirectory(clang)
+    set(LLVM_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/llvm/include ${CMAKE_SOURCE_DIR}/llvm/include)
+    set(CLANG_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/clang/include ${CMAKE_SOURCE_DIR}/clang/include)
+endif()
 add_subdirectory(src)
 add_subdirectory(test)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,11 @@ if(USE_INSTALLED_CLANG)
     endmacro(add_clang_executable)
     set(CLANG_INCLUDE_DIRS)
     link_directories(${LLVM_LIBRARY_DIRS})
+    # Assume we're using newer than r130246 by default
+    option(CLANG_NEWER_THAN_R130246 "Is the version of Clang in use trunk r130246 or newer?" ON)
+    if(CLANG_NEWER_THAN_R130246)
+      add_definitions(-DCLANG_POST_R130246)
+    endif()
 else()
     # Patch LLVM CMake script to set USE_FOLDERS property to OFF.
     configure_file(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,13 +9,17 @@ include_directories(${LLVM_INCLUDE_DIRS}
 
 set(LLVM_USED_LIBS
     clangFrontend
+    clangSerialization
     clangDriver
     clangSema
     clangAnalysis
     clangAST
     clangParse
+    clangSema
     clangLex
     clangBasic
+    LLVMSupport
+    LLVMMC
 )
 
 add_clang_executable(find-unnecessary-includes

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,11 +2,8 @@
 
 include(HandleLLVMOptions)
 
-include_directories(
-    ${CMAKE_BINARY_DIR}/llvm/include
-    ${CMAKE_SOURCE_DIR}/llvm/include
-    ${CMAKE_BINARY_DIR}/clang/include
-    ${CMAKE_SOURCE_DIR}/clang/include
+include_directories(${LLVM_INCLUDE_DIRS}
+    ${CLANG_INCLUDE_DIRS}
     ${CMAKE_BINARY_DIR}/include
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,3 +22,6 @@ add_clang_executable(find-unnecessary-includes
     main.cpp
     UnnecessaryIncludeFinder.cpp
 )
+
+install(TARGETS find-unnecessary-includes
+    RUNTIME DESTINATION bin)

--- a/src/UnnecessaryIncludeFinder.cpp
+++ b/src/UnnecessaryIncludeFinder.cpp
@@ -174,6 +174,21 @@ public:
     delegate_(delegate)
   { }
 
+#ifdef CLANG_POST_R130246
+  virtual void InclusionDirective(
+      clang::SourceLocation hashLoc,
+      const clang::Token& includeToken,
+      llvm::StringRef fileName,
+      bool isAngled,
+      const clang::FileEntry* pFile,
+      clang::SourceLocation endLoc,
+      llvm::StringRef SearchPath,
+      llvm::StringRef RelativePath)
+  {
+    delegate_.InclusionDirective(
+        hashLoc, includeToken, fileName, isAngled, pFile, endLoc, SearchPath, RelativePath);
+  }
+#else
   virtual void InclusionDirective (
       SourceLocation hashLoc,
       const clang::Token& includeToken,
@@ -186,7 +201,7 @@ public:
     delegate_.InclusionDirective(
         hashLoc, includeToken, fileName, isAngled, pFile, endLoc, rawPath);
   }
-
+#endif
   virtual void FileChanged (
       SourceLocation newLocation,
       PPCallbacks::FileChangeReason reason,
@@ -248,7 +263,17 @@ UnnecessaryIncludeFinder::markUsed (
     action_.allUsedHeaders_.insert(fileName);
   }
 }
-
+#ifdef CLANG_POST_R130246
+void UnnecessaryIncludeFinder::InclusionDirective(
+      clang::SourceLocation hashLoc,
+      const clang::Token& includeToken,
+      llvm::StringRef fileName,
+      bool isAngled,
+      const clang::FileEntry* pFile,
+      clang::SourceLocation endLoc,
+      llvm::StringRef SearchPath,
+      llvm::StringRef RelativePath)
+#else
 void
 UnnecessaryIncludeFinder::InclusionDirective (
     SourceLocation hashLoc,
@@ -258,6 +283,7 @@ UnnecessaryIncludeFinder::InclusionDirective (
     const FileEntry* pFile,
     SourceLocation endLoc,
     const SmallVectorImpl<char>& rawPath)
+#endif
 {
   std::string directiveLocation;
   raw_string_ostream rso(directiveLocation);

--- a/src/UnnecessaryIncludeFinder.cpp
+++ b/src/UnnecessaryIncludeFinder.cpp
@@ -370,7 +370,7 @@ UnnecessaryIncludeFinder::HandleTranslationUnit (ASTContext& astContext)
 bool
 UnnecessaryIncludeFinder::VisitTypedefTypeLoc (TypedefTypeLoc typeLoc)
 {
-  markUsed(typeLoc.getTypedefDecl()->getLocation(), typeLoc.getBeginLoc());
+  markUsed(typeLoc.getTypePtr()->getDecl()->getLocation(), typeLoc.getBeginLoc());
   return true;
 }
 

--- a/src/UnnecessaryIncludeFinder.h
+++ b/src/UnnecessaryIncludeFinder.h
@@ -180,6 +180,17 @@ public:
    */
   clang::PPCallbacks* createPreprocessorCallbacks();
 
+#ifdef CLANG_POST_R130246
+  virtual void InclusionDirective(
+      clang::SourceLocation hashLoc,
+      const clang::Token& includeToken,
+      llvm::StringRef fileName,
+      bool isAngled,
+      const clang::FileEntry* pFile,
+      clang::SourceLocation endLoc,
+      llvm::StringRef SearchPath,
+      llvm::StringRef RelativePath);
+#else
   virtual void InclusionDirective(
       clang::SourceLocation hashLoc,
       const clang::Token& includeToken,
@@ -188,6 +199,7 @@ public:
       const clang::FileEntry* pFile,
       clang::SourceLocation endLoc,
       const llvm::SmallVectorImpl<char>& rawPath);
+#endif
 
   virtual void FileChanged(
       clang::SourceLocation newLocation,


### PR DESCRIPTION
I've made a few improvements in these commits - commit messages should be fairly clear. Tested with r132995 trunk of clang and llvm on Ubuntu 10.04 x64, building clang and llvm with clang 2.9 branch.
